### PR TITLE
Fixing high speed movements after clicking resume option

### DIFF
--- a/gamecontroller.cpp
+++ b/gamecontroller.cpp
@@ -2,10 +2,13 @@
 #include <QGraphicsScene>
 #include <QKeyEvent>
 #include <QMessageBox>
+#include <QAction>
+#include <iostream>
 
 #include "gamecontroller.h"
 #include "food.h"
 #include "snake.h"
+#include "mainwindow.h"
 
 GameController::GameController(QGraphicsScene &scene, QObject *parent) :
     QObject(parent),
@@ -20,8 +23,9 @@ GameController::GameController(QGraphicsScene &scene, QObject *parent) :
 
     scene.addItem(snake);
     scene.installEventFilter(this);
-
-    resume();
+    //resume();
+    connect(&timer, SIGNAL(timeout()), &scene, SLOT(advance()));
+   isPause = false;
 }
 
 GameController::~GameController()
@@ -106,15 +110,22 @@ void GameController::pause()
     disconnect(&timer, SIGNAL(timeout()),
                &scene, SLOT(advance()));
     isPause = true;
+    setResume();
 }
 
 void GameController::resume()
 {
-    connect(&timer, SIGNAL(timeout()),
-            &scene, SLOT(advance()));
-    isPause = false;
+    connect(&timer, SIGNAL(timeout()), &scene, SLOT(advance()));
+   isPause = false;
+   setResume();
 }
-
+void GameController :: setResume(){
+    if(isPause == true){
+        resumeAction->setEnabled(true);
+    }else{
+        resumeAction->setEnabled(false);
+    }
+}
 bool GameController::eventFilter(QObject *object, QEvent *event)
 {
     if (event->type() == QEvent::KeyPress) {

--- a/gamecontroller.h
+++ b/gamecontroller.h
@@ -3,7 +3,8 @@
 
 #include <QObject>
 #include <QTimer>
-
+#include <QAction>
+#include "mainwindow.h"
 class QGraphicsScene;
 class QKeyEvent;
 
@@ -21,22 +22,22 @@ public:
     void snakeAteFood(Food *food);
 //    void snakeHitWall(Snake *snake, Wall *wall);
     void snakeAteItself();
-
+    QAction *getResmueAction(){ return resumeAction;}
+    void setResumeAction(QAction* r){ resumeAction = r; }
 public slots:
     void pause();
     void resume();
     void gameOver();
-
 protected:
      bool eventFilter(QObject *object, QEvent *event);
 
 private:
     void handleKeyPressed(QKeyEvent *event);
     void addNewFood();
-
+    void setResume();
+    QAction * resumeAction;
     QTimer timer;
     QGraphicsScene &scene;
-
     Snake *snake;
     bool isPause;
 };

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -23,7 +23,6 @@ MainWindow::MainWindow(QWidget *parent)
 
 	createActions();
 	createMenus();
-
     initScene();
     initSceneBackground();
 
@@ -58,7 +57,9 @@ void MainWindow::createActions()
 
 	resumeAction = new QAction(tr("&Resume"), this);
 	resumeAction->setStatusTip(tr("Resume..."));
-	connect(resumeAction, &QAction::triggered, game, &GameController::resume);
+    resumeAction->setEnabled(false);
+    game->setResumeAction(resumeAction);
+    connect(resumeAction, &QAction::triggered, game, &GameController::resume);
 
 	gameHelpAction = new QAction(tr("Game &Help"), this);
 	gameHelpAction->setShortcut(tr("Ctrl+H"));

--- a/snake.pro
+++ b/snake.pro
@@ -29,4 +29,3 @@ HEADERS  += mainwindow.h \
 RESOURCES += \
     res.qrc
 
-RC_FILE += myapp.rc


### PR DESCRIPTION
Hi, please check my changes.
I have been working to fix a bug in the game and i already opened an [issue](https://github.com/devbean/snake-game/issues/5) . \
My fix consists of disabling the resume option from the menu while the snake is moving and a enabling it while the game is paused. In that way you can avoid too many clicks on that option.
Contact me for any issues or suggestions.